### PR TITLE
Update chatbot docs and API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,8 @@ Personal Portfolio
    ```bash
    python chatbot.py
    ```
-4. Open `index.html` in your browser and ask questions in the chat box.
+4. In a separate terminal, start a local HTTP server to serve the site:
+   ```bash
+   python -m http.server
+   ```
+   Then open `http://localhost:8000/index.html` in your browser and ask questions in the chat box.

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
   const log = document.getElementById("chat-log");
   const input = document.getElementById("chat-input");
+  const API_URL = window.API_URL || "http://localhost:5000/chat";
 
   if (!log || !input) return;
 
@@ -13,7 +14,7 @@ document.addEventListener("DOMContentLoaded", () => {
     log.innerHTML += `<div><strong>You:</strong> ${question}</div>`;
 
     try {
-      const res = await fetch("/chat", {
+      const res = await fetch(API_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: question })


### PR DESCRIPTION
## Summary
- script.js now points to an explicit API endpoint (`http://localhost:5000/chat`)
- README instructions updated to serve the site via a local HTTP server

## Testing
- `python -m py_compile chatbot.py`
- `pip install -r requirements.txt` *(fails: ChatGPT openai library error when running server)*
- `curl -X POST http://localhost:5000/chat -H 'Content-Type: application/json' -d '{"message":"Hello"}'` *(server error due to OpenAI dependency)*

------
https://chatgpt.com/codex/tasks/task_e_683f624d253c8332ba5e469363b52b26