### PR TITLE
Clarify local setup for /chat endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,16 @@ Personal Portfolio
    ```bash
    python chatbot.py
    ```
-4. Open `index.html` in your browser and ask questions in the chat box.
+4. Serve the website locally so that the browser can fetch `/chat`. You can use
+   a simple HTTP server or Jekyll:
+   ```bash
+   # option 1
+   python -m http.server
+
+   # option 2 (if you use Jekyll)
+   bundle exec jekyll serve
+   ```
+   The Flask app listens on `PORT` (defaults to `5000`). Whichever URL you load
+   the site from must be able to reach the Flask server at the same URL used in
+   `script.js` (currently `fetch('/chat')`). Configure your ports accordingly so
+   that the browser can POST to `/chat`.


### PR DESCRIPTION
## Summary
- document how to serve the site instead of opening the HTML file directly
- note that `script.js` uses `/chat` so the Flask server must be reachable on the same URL/port

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_683f6252fc6c8332b727ed87984bf688